### PR TITLE
fix: screenshot 无法获取 dataURL

### DIFF
--- a/src/js/controller.js
+++ b/src/js/controller.js
@@ -243,9 +243,8 @@ class Controller {
                     link.click();
                     document.body.removeChild(link);
                     URL.revokeObjectURL(dataURL);
+                    this.player.events.trigger('screenshot', dataURL);
                 });
-
-                this.player.events.trigger('screenshot', dataURL);
             });
         }
     }


### PR DESCRIPTION
`dataURL` 的获取在 `toBlob` 的回调方法中，原始方法触发 `screenshot` 时，传递的 `dataURL ` 始终为 `undefined`