### PR TITLE
更新指南文档中弹幕直播部分

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -747,11 +747,11 @@ const dp = new DPlayer({
     apiBackend: {
         read: function (options) {
             console.log('Pretend to connect WebSocket');
-            callback();
+            options.success([]);
         },
         send: function (options) {
             console.log('Pretend to send danmaku via WebSocket', options.data);
-            callback();
+            options.success();
         },
     },
     video: {

--- a/docs/zh/guide.md
+++ b/docs/zh/guide.md
@@ -729,13 +729,13 @@ const dp = new DPlayer({
     live: true,
     danmaku: true,
     apiBackend: {
-        read: function (endpoint, callback) {
+        read: function (options) {
             console.log('Pretend to connect WebSocket');
-            callback();
+            options.success([]);
         },
-        send: function (endpoint, danmakuData, callback) {
-            console.log('Pretend to send danmaku via WebSocket', danmakuData);
-            callback();
+        send: function (options) {
+            console.log('Pretend to send danmaku via WebSocket', options.data);
+            options.success();
         },
     },
     video: {


### PR DESCRIPTION
适配commit [#cd6afd7f](https://github.com/MoePlayer/DPlayer/commit/cd6afd7fb504f2e19b827ee9ea99db96813ac76e) optimize danmaku request

另外提一下，如果函数read回调success不带[],则会造成关闭弹幕且刷新页面后无法打开弹幕的情况(空指针)

如果可以定性为Bug,我会提交相应的修复PR