### PR TITLE
Fix the problem of getting highlight exception after perload is enabl…

### DIFF
--- a/src/js/controller.js
+++ b/src/js/controller.js
@@ -66,7 +66,7 @@ class Controller {
         this.player.on('durationchange', () => {
             if (this.player.video.duration !== 1 && this.player.video.duration !== Infinity) {
                 if (this.player.options.highlight) {
-                    const highlights = document.querySelectorAll('.dplayer-highlight');
+                    const highlights = this.player.template.playedBarWrap.querySelectorAll('.dplayer-highlight');
                     [].slice.call(highlights, 0).forEach((item) => {
                         this.player.template.playedBarWrap.removeChild(item);
                     });


### PR DESCRIPTION
Fix the problem of getting highlight exception after perload is enabled in multiple instances。

When preload is enabled, multiple new dspallers are used and the highlight is passed in, the highlight cannot be displayed normally.

The reason is that the current document is obtained instead of the current dplayer instance


-----------------------------------------------------

当启用preload，使用多个new Dplayer并传入highlight后，会无法正常显示highlight。
原因是，获取的是当前document，而不是当前Dplayer实例


-----------------------------------------------------

reappear：
```
window.dp0 = new DPlayer({
    container: document.getElementById('dplayer0'),
    preload: "auto",
    video: {
        url: 'http://static.smartisanos.cn/common/video/t1-ui.mp4',
        pic: 'http://static.smartisanos.cn/pr/img/video/video_03_cc87ce5bdb.jpg',
        thumbnails: 'http://static.smartisanos.cn/pr/img/video/video_03_cc87ce5bdb.jpg'
    },
    highlight: [
        {
            time: 20,
            text: '这是第 20 秒',
        },
        {
            time: 120,
            text: '这是 2 分钟',
        },
        {
            time: 1500,
            text: '这是 1500',
        },
    ],
});
// dp1
window.dp1 = new DPlayer({
    container: document.getElementById('dplayer1'),   
    preload: "auto",
    video: {
        url: 'http://static.smartisanos.cn/common/video/t1-ui.mp4',
        pic: 'http://static.smartisanos.cn/pr/img/video/video_03_cc87ce5bdb.jpg',
        thumbnails: 'http://static.smartisanos.cn/pr/img/video/video_03_cc87ce5bdb.jpg'
    },
    highlight: [
        {
            time: 20,
            text: '这是第 20 秒',
        },
        {
            time: 120,
            text: '这是 2 分钟',
        },
        {
            time: 1500,
            text: '这是 1500',
        },
    ],
});

```
