### PR TITLE
chore: remove unnecessary rxjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
     "dependencies": {
         "axios": "0.27.2",
         "balloon-css": "^1.0.3",
-        "promise-polyfill": "8.2.3",
-        "rxjs": "^7.5.6"
+        "promise-polyfill": "8.2.3"
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,7 +29,6 @@ specifiers:
   prettier-check: ^2.0.0
   pretty-quick: ^3.0.0
   promise-polyfill: 8.2.3
-  rxjs: ^7.5.6
   strip-loader: ^0.1.2
   style-loader: ^3.3.1
   svg-inline-loader: 0.8.2
@@ -44,7 +43,6 @@ dependencies:
   axios: 0.27.2
   balloon-css: 1.2.0
   promise-polyfill: 8.2.3
-  rxjs: 7.5.6
 
 devDependencies:
   '@babel/core': 7.18.10
@@ -6132,12 +6130,6 @@ packages:
       queue-microtask: 1.2.3
     dev: true
 
-  /rxjs/7.5.6:
-    resolution: {integrity: sha512-dnyv2/YsXhnm461G+R/Pe5bWP41Nm6LBXEYWI6eiFP4fiwx6WRI/CD0zbdVAudd9xwLEF2IDcKXLHit0FYjUzw==}
-    dependencies:
-      tslib: 2.4.0
-    dev: false
-
   /safe-buffer/5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
     dev: true
@@ -6742,6 +6734,7 @@ packages:
 
   /tslib/2.4.0:
     resolution: {integrity: sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==}
+    dev: true
 
   /type-check/0.3.2:
     resolution: {integrity: sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==}

--- a/src/js/controller.js
+++ b/src/js/controller.js
@@ -1,7 +1,6 @@
 import utils from './utils';
 import Thumbnails from './thumbnails';
 import Icons from './icons';
-import { Subject } from 'rxjs';
 
 let cast;
 let runOnce = true;
@@ -315,23 +314,19 @@ class Controller {
                 this.initChromecast();
             }
             const discoverDevices = () => {
-                const subj = new Subject();
                 cast.requestSession(
                     (s) => {
                         this.session = s;
-                        subj.next('CONNECTED');
                         launchMedia(this.player.options.video.url);
                     },
                     (err) => {
                         if (err.code === 'cancel') {
                             this.session = undefined;
-                            subj.next('CANCEL');
                         } else {
                             console.error('Error selecting a cast device', err);
                         }
                     }
                 );
-                return subj;
             };
 
             const launchMedia = (media) => {


### PR DESCRIPTION
I noticed that since the DPlayer 1.27, the bundle size is increased by 50 KiB. I noticed that the `rxjs` is introduced by #943, which is entirely unnecessary to enable Chromecast support. Blame 
@dpgiakatos.

The PR removes the unused `rxjs` from DPlayer and decreases the bundle size by 50.7 KiB.
