### PR TITLE
修正中文文档首页“快速上手”链接指向错误 Fix the "快速上手" link of the Chinese documentation.

### DIFF
--- a/docs/zh/README.md
+++ b/docs/zh/README.md
@@ -9,4 +9,4 @@ footer: MIT Licensed | Made with love by DIYgod
   <DPlayer :immediate="true"></DPlayer>
 </div>
 
-<div class="hero custom"><p class="action"><router-link to="/guide/" class="nav-link action-button">快速上手 →</router-link></p></div>
+<div class="hero custom"><p class="action"><router-link to="/zh/guide/" class="nav-link action-button">快速上手 →</router-link></p></div>

--- a/docs/zh/README.md
+++ b/docs/zh/README.md
@@ -1,7 +1,7 @@
 ---
 home: true
 actionText: Get Started →
-actionLink: /guide/
+actionLink: /zh/guide/
 footer: MIT Licensed | Made with love by DIYgod
 ---
 


### PR DESCRIPTION
[我提交了issues](https://github.com/DIYgod/DPlayer/issues/1312)

由于没有回应，我琢磨了一下应该是这样修正的
抱歉我对项目并不是很熟悉，doc的构建也不懂
劳烦审计一下修改是否有误，这是我人生第一个PR😂

Since there was no response, I figured I'd fix it like this
I'm sorry I'm not familiar with the project and the DOC build
Please audit the revision is wrong, this is my first PR
