### PR TITLE
Prevent the control bar from changing when a touchstart or mousedown event is emitted on it

### DIFF
--- a/src/js/controller.js
+++ b/src/js/controller.js
@@ -122,11 +122,11 @@ class Controller {
             percentage = Math.min(percentage, 1);
             this.player.bar.set('played', percentage, 'width');
             this.player.seek(this.player.bar.get('played') * this.player.video.duration);
-            this.player.timer.enable('progress');
+            this.player.moveBar = false;
         };
 
         this.player.template.playedBarWrap.addEventListener(utils.nameMap.dragStart, () => {
-            this.player.timer.disable('progress');
+            this.player.moveBar = true;
             document.addEventListener(utils.nameMap.dragMove, thumbMove);
             document.addEventListener(utils.nameMap.dragEnd, thumbUp);
         });

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -182,6 +182,8 @@ class DPlayer {
             this.play();
         }
 
+        this.moveBar = false;
+
         index++;
         instances.push(this);
     }
@@ -537,7 +539,9 @@ class DPlayer {
         });
 
         this.on('timeupdate', () => {
-            this.bar.set('played', this.video.currentTime / this.video.duration, 'width');
+            if (!this.moveBar) {
+                this.bar.set('played', this.video.currentTime / this.video.duration, 'width');
+            }
             const currentTime = utils.secondToTime(this.video.currentTime);
             if (this.template.ptime.innerHTML !== currentTime) {
                 this.template.ptime.innerHTML = currentTime;


### PR DESCRIPTION
改善当触摸在控制栏没有拖动或离开时，控制条bar会随着timeupdate事件更新位置，导致bar的位置会出现偏移的问题