### PR TITLE
更改dashjs调用方式

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -435,7 +435,8 @@ class DPlayer {
                 // https://github.com/Dash-Industry-Forum/dash.js
                 case 'dash':
                     if (window.dashjs) {
-                        const dashjsPlayer = window.dashjs.MediaPlayer().create().initialize(video, video.src, false);
+                        const dashjsPlayer = window.dashjs.MediaPlayer().create();
+                        dashjsPlayer.initialize(video, video.src, false, 0);
                         const options = this.options.pluginOptions.dash;
                         dashjsPlayer.updateSettings(options);
                         this.plugins.dash = dashjsPlayer;


### PR DESCRIPTION
dashjs API变更，init函数不再返回player对象，需要将create与init分开。